### PR TITLE
Fix child links

### DIFF
--- a/_includes/feature/audio.html
+++ b/_includes/feature/audio.html
@@ -24,7 +24,7 @@
 {%- capture audio_caption -%}{{ include.caption }}{%- endcapture -%}
 {% else %}
 {%- assign item = site.data[site.metadata] | where: "objectid", include.objectid | first -%}
-{%- capture audio_link -%}{{ '/items/' | append: item.objectid | append: '.html' | relative_url }}{%- endcapture -%}
+{%- capture audio_link -%}{{ '/items/' | relative_url }}{% if item.parentid %}{{ item.parentid }}.html#{{ item.objectid }}{% else %}{{ item.objectid }}.html{% endif %}{%- endcapture -%}
 {%- capture src -%}{{ item.object_location | relative_url }}{% endcapture %}
 {%- capture audio_caption -%}{% if include.caption %}{{ include.caption }}{% else %}{{ item.title }}{% endif %}{%- endcapture -%}
 {% endif %}

--- a/_includes/feature/image.html
+++ b/_includes/feature/image.html
@@ -34,7 +34,7 @@
         {%- capture image_link -%}{{ links[forloop.index0] | default: image_src }}{%- endcapture -%}
     {% else %}
         {%- assign figure = site.data[site.metadata] | where: "objectid", i | first -%}
-        {%- capture image_link -%}{{ '/items/' | append: figure.objectid | append: '.html' | relative_url }}{% endcapture %}
+        {%- capture image_link -%}{{ '/items/' | relative_url }}{% if figure.parentid %}{{ figure.parentid }}.html#{{ figure.objectid }}{% else %}{{ figure.objectid }}.html{% endif %}{% endcapture %}
         {%- capture image_caption -%}{{ captions[forloop.index0] | default: figure.title }}{%- endcapture -%}
         {%- capture image_alt -%}{{ alts[forloop.index0] | default: figure.image_alt_text | default: figure.description | default: figure.title }}{%- endcapture -%}
         {%- capture image_src -%}{{ figure.image_small | default: figure.object_location | relative_url }}{% endcapture %}

--- a/_includes/feature/pdf.html
+++ b/_includes/feature/pdf.html
@@ -28,7 +28,7 @@
 {% else %}
 {%- assign item = site.data[site.metadata] | where: "objectid", include.objectid | first -%}
 {%- capture src -%}{{ item.object_location | relative_url }}{% endcapture %}
-{%- capture pdf_link -%}{{ '/items/' | append: item.objectid | append: '.html' | relative_url }}{%- endcapture -%}
+{%- capture pdf_link -%}{{ '/items/' | relative_url }}{% if item.parentid %}{{ item.parentid }}.html#{{ item.objectid }}{% else %}{{ item.objectid }}.html{% endif %}{%- endcapture -%}
 {%- capture pdf_caption -%}{% if include.caption %}{{ include.caption }}{% else %}{{ item.title }}{% endif %}{%- endcapture -%}
 {% endif %}
 <div class="text-center">

--- a/_includes/feature/video.html
+++ b/_includes/feature/video.html
@@ -27,7 +27,7 @@
     {% capture raw_src %}{{ include.objectid }}{% endcapture %}
 {%- else -%}
     {%- assign item = site.data[site.metadata] | where: "objectid", include.objectid | first -%}
-    {% capture video_caption %}{% if include.caption %}{{ include.caption }}{% else %}<a href="{{ '/items/' | append: item.objectid | append: '.html' | relative_url}}">{{ item.title }}</a>{% endif %}{% endcapture %}
+    {% capture video_caption %}{% if include.caption %}{{ include.caption }}{% else %}<a href="{{ '/items/' | relative_url }}{% if item.parentid %}{{ item.parentid }}.html#{{ item.objectid }}{% else %}{{ item.objectid }}.html{% endif %}">{{ item.title }}</a>{% endif %}{% endcapture %}
     {% capture raw_src %}{{ item.object_location }}{% endcapture %}
 {%- endif -%}
 {%- if raw_src contains 'vimeo' -%}

--- a/_includes/js/map-js.html
+++ b/_includes/js/map-js.html
@@ -25,7 +25,8 @@
         {% if item.display_template %}"template": {{ item.display_template | escape | jsonify }}, {%- endif -%}
         {% if item.format %}"format": {{ item.format | escape | jsonify }}, {%- endif -%}
         {% if item.image_alt_text %}"alt": {{ item.image_alt_text | escape | jsonify }}, {%- endif -%}
-        "title": {{ item.title | escape | jsonify }}, "link": "{% if item.parentid %}{{ item.parentid }}.html#{{ item.objectid }}{% else %}{{ item.objectid }}.html{% endif %}",
+        {% if item.parentid %}"parent": {{ item.parentid | jsonify }}, {%- endif -%}
+        "title": {{ item.title | escape | jsonify }},
         "id": {{ item.objectid | jsonify }} 
     } }{% unless forloop.last %}, {% endunless %}{% endfor %}
     ]};
@@ -116,7 +117,7 @@
         {% if site.data.theme.map-search == true %}/* bind feature for search */
         feature.layer = layer;{% endif %}
         // find item link
-        var itemHref = '{{ "/items/" | relative_url }}' + feature.properties.link;
+        var itemHref = `{{ '/items/' | relative_url }}${ feature.properties.parent ? feature.properties.parent + ".html#" + feature.properties.id : feature.properties.id + ".html"}`;
         // find image
         var imgAlt = feature.properties.alt ? feature.properties.alt : feature.properties.title;
         var thumbImg;

--- a/_layouts/timeline.html
+++ b/_layouts/timeline.html
@@ -49,7 +49,7 @@ custom-foot: js/timeline-js.html
                     {%- assign inYear = items | where_exp: 'item', 'item[field] contains year' -%}
                     {% for item in inYear %}
                     <div class="col-lg-4 col-md-6">
-                        <a href="{% if item.parentid == nil %}{{ '/items/' | append: item.objectid | append: '.html' | relative_url }}{% elsif item.parentid %}{{ '/items/' | append: item.parentid | append: '.html' | relative_url }}#{{item.objectid }}{% endif %}" >
+                        <a href="{{ '/items/' | relative_url }}{% if item.parentid %}{{ item.parentid }}.html#{{ item.objectid }}{% else %}{{ item.objectid }}.html{% endif %}" >
                             {% if item.image_thumb %}
                             <img class="lazyload img-thumbnail timeline-thumb" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 3 2'%3E%3C/svg%3E" data-src="{{ item.image_thumb | relative_url }}" alt="{{ item.image_alt_text | default: item.description | default: item.title | escape }}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ item.title | escape }}">
                             {% else %}

--- a/assets/data/geodata.json
+++ b/assets/data/geodata.json
@@ -17,7 +17,7 @@
                 {% for f in fields %}{% if item[f] %}{{ f | jsonify }}: {{ item[f] | jsonify }},{% endif %}
                 {% endfor %}{% if item.image_thumb %}"object_thumb": "{{ item.image_thumb | absolute_url }}",{% endif %}
                 "object_location": "{{ item.object_location | absolute_url }}",
-                "reference_url": "{% if item.parentid %}{{ '/items/' | append: item.parentid | append: '.html#' | append: item.objectid | absolute_url }}{% else %}{{ '/items/' | append: item.objectid | append: '.html' | absolute_url }}{% endif %}"
+                "reference_url": "{{ '/items/' | relative_url }}{% if item.parentid %}{{ item.parentid }}.html#{{ item.objectid }}{% else %}{{ item.objectid }}.html{% endif %}"
             }
         }{% unless forloop.last %}, {% endunless %}{% endfor %}
     ]

--- a/assets/data/metadata.csv
+++ b/assets/data/metadata.csv
@@ -4,5 +4,5 @@
 {%- assign items = site.data[site.metadata] | where_exp: 'item','item.objectid' -%}
 {%- assign fields = site.data.theme.metadata-export-fields | split: "," -%}
 {{ fields | join: "," }},object_thumb,object_location,reference_url
-{% for item in items %}{% for f in fields %}"{{ item[f] | escape }}",{% endfor %}"{{ item.image_thumb | absolute_url }}","{{ item.object_location | absolute_url }}","{% if item.parentid %}{{ '/items/' | append: item.parentid | append: '.html#' | append: item.objectid | absolute_url }}{% else %}{{ '/items/' | append: item.objectid | append: '.html' | absolute_url }}{% endif %}"
+{% for item in items %}{% for f in fields %}"{{ item[f] | escape }}",{% endfor %}"{{ item.image_thumb | absolute_url }}","{{ item.object_location | absolute_url }}",{{ '/items/' | relative_url }}{% if item.parentid %}{{ item.parentid }}.html#{{ item.objectid }}{% else %}{{ item.objectid }}.html{% endif %}
 {% endfor %}

--- a/assets/data/metadata.json
+++ b/assets/data/metadata.json
@@ -9,7 +9,7 @@
         {% for f in fields %}{% if item[f] %}{{ f | jsonify }}: {{ item[f] | jsonify }},{% endif %}
         {% endfor %}{% if item.image_thumb %}"object_thumb": "{{ item.image_thumb | absolute_url }}",{% endif %}
         "object_location": "{{ item.object_location | absolute_url }}",
-        "reference_url": {% if item.parentid %}{{ '/items/' | append: item.parentid | append: '.html#' | append: item.objectid | absolute_url | jsonify }}{% else %}{{ '/items/' | append: item.objectid | append: '.html' | absolute_url | jsonify }}{% endif %}
+        "reference_url": "{{ '/items/' | relative_url }}{% if item.parentid %}{{ item.parentid }}.html#{{ item.objectid }}{% else %}{{ item.objectid }}.html{% endif %}"
     }{% unless forloop.last %},{% endunless %}
     {% endfor %}
 ] }

--- a/assets/data/timelinejs.json
+++ b/assets/data/timelinejs.json
@@ -22,7 +22,7 @@
         "media": {
           "url": "{{ item.image_small | default: item.image_thumb | default: item.object_location | relative_url }}",
           "caption": {{ item.title | jsonify }},
-          "link": {% if item.parentid %}{{ '/items/' | append: item.parentid | append: '.html#' | append: item.objectid | relative_url | jsonify }}{% else %}{{ '/items/' | append: item.objectid | append: '.html' | relative_url | jsonify }}{% endif %}
+          "link": "{{ '/items/' | relative_url }}{% if item.parentid %}{{ item.parentid }}.html#{{ item.objectid }}{% else %}{{ item.objectid }}.html{% endif %}"
         },
         "start_date": { 
           {% if item.date contains '-' %}{% assign dates = item.date | strip | split: '-' %}


### PR DESCRIPTION
This PR:

- fixes broken links to child items of compound_objects found in feature includes #82 
- normalizes the Liquid and js logic used to figure out child/regular links so it is easier to find and customize