### PR TITLE
Changed %Y in the footer "Last updated..." display to %Y-%b-%d

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -45,7 +45,7 @@
     </div>
 
     <div class="col-md-12 text-center pt-3 pb-1">
-        <p class="text-white">Last updated {{ site.time | date: '%Y' }}</p>
+        <p class="text-white">Last updated {{ site.time | date: '%Y-%b-%d' }}</p>
     </div>
 
 </footer>


### PR DESCRIPTION
# Pull request

## Proposed changes

I found that in the footer displaying "Last updated" showing only the year (%Y) was unhelpful.  I changed the display format to "%Y-%b-%d" so it shows, for example, "2025-Feb-26" instead of just "2025".   Since the display doesn't show hours or minutes there should be few, if any, timezone issues.  

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [x] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
