### PR TITLE
60/auto center map

### DIFF
--- a/_data/theme.yml
+++ b/_data/theme.yml
@@ -40,6 +40,7 @@ locations-stopwords: # set of subjects separated by ; that will be removed from 
 # see _data/map-config.csv for field display options
 latitude: 46.727485 #to determine center of map
 longitude: -117.014185 #to determine center of map
+auto-center-map: true # have the map auto fit all features into its view, overrides configured latitude and longitude, will not do anything if location coordinates were specified in the URL query parameters
 zoom-level: 5 # zoom level for map 
 map-base: Esri_WorldStreetMap # set default base map, choose from: Esri_WorldStreetMap, Esri_NatGeoWorldMap, Esri_WorldImagery, OpenStreetMap_Mapnik
 map-search: true # not suggested with large collections

--- a/_data/theme.yml
+++ b/_data/theme.yml
@@ -38,10 +38,10 @@ locations-stopwords: # set of subjects separated by ; that will be removed from 
 # MAP PAGE
 #
 # see _data/map-config.csv for field display options
-latitude: 46.727485 #to determine center of map
-longitude: -117.014185 #to determine center of map
-auto-center-map: true # have the map auto fit all features into its view, overrides configured latitude and longitude, will not do anything if location coordinates were specified in the URL query parameters
-zoom-level: 5 # zoom level for map 
+auto-center-map: true # have the map auto fit all features into its view
+latitude: 46.727485 # to manually center map if not using auto-center-map option
+longitude: -117.014185 # to manually center map if not using auto-center-map option
+zoom-level: 5 # zoom level for map if not using auto-center-map option
 map-base: Esri_WorldStreetMap # set default base map, choose from: Esri_WorldStreetMap, Esri_NatGeoWorldMap, Esri_WorldImagery, OpenStreetMap_Mapnik
 map-search: true # not suggested with large collections
 map-search-fuzziness: 0.35 # fuzzy search range from 1 = anything to 0 = exact match only

--- a/_includes/js/map-js.html
+++ b/_includes/js/map-js.html
@@ -31,15 +31,15 @@
     } }{% unless forloop.last %}, {% endunless %}{% endfor %}
     ]};
 
-    /* check for url parameters and set initial view options */ 
+    /* check for url parameters and setup initial view options */ 
     let url = new URL(window.location);
     const locationSearchParams = url.searchParams.get('location');
     var mapCenter = locationSearchParams ? locationSearchParams.split(',') : [{{ site.data.theme.latitude | default: 46.727485 }}, {{ site.data.theme.longitude | default: -117.014185 }}];
     var mapZoom = locationSearchParams ? 16 : {{ site.data.theme.zoom-level | default: 5 }};
     var markerFilter = url.searchParams.get('marker') ? url.searchParams.get('marker') : "";
 
-    /* init map, set center and zoom */
-    var map = L.map('map').setView(mapCenter, mapZoom);
+    /* init map */
+    var map = L.map('map');
 
     /* add map layer options */
     var Esri_WorldStreetMap = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}', {
@@ -152,14 +152,20 @@
     }){% if site.data.theme.map-cluster != true %}.addTo(map);{% else %};
     map.addLayer(markers);{% endif %}
 
-    /* if no location was specified in the URL query parameters, auto center the map if configured  */
     {% if site.data.theme.auto-center-map == true %}
+    /* if no location was specified in the URL query parameters, auto center the map */
     if (locationSearchParams === null) {
         const featureBounds = mapFeatures.getBounds()
         if (featureBounds?.isValid()) {
             map.fitBounds(featureBounds);
         }
+    } else {
+        /* set map view based on URL parameters */
+        map.setView(mapCenter, mapZoom);
     }
+    {% else %}
+    /* set map view based on configuration or URL parameters */
+    map.setView(mapCenter, mapZoom);
     {% endif %}
     
     {% if site.data.theme.map-cluster == true and site.data.theme.map-search == true %}

--- a/_includes/js/map-js.html
+++ b/_includes/js/map-js.html
@@ -33,8 +33,9 @@
 
     /* check for url parameters and set initial view options */ 
     let url = new URL(window.location);
-    var mapCenter = url.searchParams.get('location') ? url.searchParams.get('location').split(',') : [{{ site.data.theme.latitude | default: 46.727485 }}, {{ site.data.theme.longitude | default: -117.014185 }}];
-    var mapZoom = url.searchParams.get('location') ? 16 : {{ site.data.theme.zoom-level | default: 5 }};
+    const locationSearchParams = url.searchParams.get('location');
+    var mapCenter = locationSearchParams ? locationSearchParams.split(',') : [{{ site.data.theme.latitude | default: 46.727485 }}, {{ site.data.theme.longitude | default: -117.014185 }}];
+    var mapZoom = locationSearchParams ? 16 : {{ site.data.theme.zoom-level | default: 5 }};
     var markerFilter = url.searchParams.get('marker') ? url.searchParams.get('marker') : "";
 
     /* init map, set center and zoom */
@@ -150,6 +151,16 @@
         pointToLayer: objectMarkers
     }){% if site.data.theme.map-cluster != true %}.addTo(map);{% else %};
     map.addLayer(markers);{% endif %}
+
+    /* if no location was specified in the URL query parameters, auto center the map if configured  */
+    {% if site.data.theme.auto-center-map == true %}
+    if (locationSearchParams === null) {
+        const featureBounds = mapFeatures.getBounds()
+        if (featureBounds?.isValid()) {
+            map.fitBounds(featureBounds);
+        }
+    }
+    {% endif %}
     
     {% if site.data.theme.map-cluster == true and site.data.theme.map-search == true %}
     /* uncluster when search is clicked */

--- a/docs/maps.md
+++ b/docs/maps.md
@@ -16,6 +16,7 @@ Set base configuration in `_data/theme.yml` map section, including:
 ```
 latitude: 46.727485 #to determine center of map
 longitude: -117.014185 #to determine center of map
+auto-center-map: true # have the map auto fit all features into its view, overrides configured latitude and longitude, will not do anything if location coordinates were specified in the URL query parameters
 zoom-level: 5 # zoom level for map 
 map-search: true # not suggested with large collections
 map-search-fuzziness: 0.35 # fuzzy search range from 1 = anything to 0 = exact match only

--- a/docs/maps.md
+++ b/docs/maps.md
@@ -11,35 +11,50 @@ With plugins:
 - cluster plugin (for search and cluster to work together), https://github.com/ghybs/Leaflet.MarkerCluster.Freezable
 - full screen, https://github.com/Leaflet/Leaflet.fullscreen
 
-Set base configuration in `_data/theme.yml` map section, including:
+## theme Configuration Options
+
+Set base configuration in "_data/theme.yml" Map section, including:
 
 ```
-latitude: 46.727485 #to determine center of map
-longitude: -117.014185 #to determine center of map
-auto-center-map: true # have the map auto fit all features into its view, overrides configured latitude and longitude, will not do anything if location coordinates were specified in the URL query parameters
-zoom-level: 5 # zoom level for map 
+auto-center-map: true # have the map auto fit all features into its view
+latitude: 46.727485 # to manually center map if not using auto-center-map option
+longitude: -117.014185 # to manually center map if not using auto-center-map option
+zoom-level: 5 # zoom level for map if not using auto-center-map option
+map-base: Esri_WorldStreetMap # set default base map, choose from: Esri_WorldStreetMap, Esri_NatGeoWorldMap, Esri_WorldImagery, OpenStreetMap_Mapnik
 map-search: true # not suggested with large collections
 map-search-fuzziness: 0.35 # fuzzy search range from 1 = anything to 0 = exact match only
 map-cluster: true # suggested for large collection or with many items in same location
 map-cluster-radius: 25 # size of clusters, from ~ 10 to 80
 ```
 
-These `theme` options will load the correct CSS and JS for leaflet features, while setting some JS configuration variables. 
-`map-cluster-radius` sets the `maxClusterRadius` which corresponds to the maximum radius a cluster can cover in pixels on the map.
+These "theme" options will load the correct CSS and JS for leaflet features, while setting some configuration variables in the javascript.
+
+With the default `auto-center-map: true` option, Leaflet will automatically center and zoom the map based on all the items added to the map--you do not need to set the latitude, longitude, or zoom-level. 
+If you would like to manually set the center and zoom level for the map, set `auto-center-map: false` and set values for the latitude, longitude, and zoom-level.
+
+The `map-search: true` option adds a Fuse-based client-side text search of the configured metadata fields (using leaflet-fusesearch plugin). 
+The index is relatively slow, so you may want to set this option to `false` if you find the map lagging.
+
+The `map-cluster: true` option clusters features on the map (using Leaflet.markercluster plugin).
+Because of the way markers are handled, for larger collections it is strongly suggested to keep cluster on, since it makes loading and navigating the map significantly more efficient.
+The `map-cluster-radius` sets the maximum radius a cluster can cover in pixels on the map.
 A smaller radius will create more, smaller clusters, and increasing will create fewer, larger clusters on the map.
 
-Next, configure the display using `_data/map-config.csv`, which controls the metadata displayed on object popups and included in search:
+## map-config.csv Options
+
+The metadata displayed on object popups and included in search is configured using using "_data/map-config.csv":
 
 - `field`: matches a column name in the metadata csv that will be displayed in object popups.
 - `display`: display name for the field to appear on popup. if blank, field will not be displayed (but could be used in search)
 - `search`: `true` or `false`/blank. If theme has `map-search` as `true`, then fields with true in this column will be indexed and displayed on the map search feature.
 
-Because of the way markers are handled, for larger collections it is strongly suggested to turn search off and cluster on.
-Cluster makes loading and navigating the map significantly more efficient.
+## URL parameters 
 
-Object pages that have lat/long will generate a "View on Map" button link. 
-These link to the `map.html` page with a query string created from their lat long and objectid.
+The map page supports parsing a query string to set the center and display an Item popup. 
 If the url includes a query string, it will be parsed and set as the map view box with full zoom and open the popup.
+
+Item pages that have lat/long will generate a "View on Map" button link. 
+These link to the "map.html" page with a query string created from their lat long and objectid.
 
 For example: 
 `/map.html?location=46.726113,-117.015671&marker=example_004`


### PR DESCRIPTION
# Pull request

## Proposed changes

For issue #60, an `auto-center-map` option is available in to be configured (either true or false). It will fit all loaded features into the initial map view if `auto-center-map` is configured to `true` and only if there is no `location` query parameter in the URL.

## Types of changes

- [ ] New feature (non-breaking change which adds functionality).
- [x] Enhancement (non-breaking change which enhances functionality)
- [ ] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist

- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
