### PR TITLE
Hidden fusesearch panel blocks touch input on mobile

### DIFF
--- a/assets/lib/leaflet/leaflet.fusesearch.css
+++ b/assets/lib/leaflet/leaflet.fusesearch.css
@@ -23,9 +23,10 @@
     position: absolute;
     height: 100%;
     width: 350px;
-    
+
     z-index: -1;
     opacity: 0;
+    pointer-events: none;
     -webkit-transition: opacity 0.3s linear;
     -moz-transition: opacity 0.3s linear;
     -o-transition: opacity 0.3s linear;
@@ -69,6 +70,7 @@
 .leaflet-fusesearch-panel.visible {
     opacity: 1;
     z-index: 2000;
+    pointer-events: auto;
 }
 
 


### PR DESCRIPTION
# Pull request
The .leaflet-fusesearch-panel is always in the DOM at full map height and 250–350 px wide. When closed it hides via opacity: 0 + z-index: -1, but opacity: 0 elements still receive touch events on mobile browsers, making that portion of the map completely unresponsive to touch.

## Proposed changes
Add pointer-events: none to the closed state and restore on .visible. Two lines of CSS, no behaviour change on desktop.


## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Enhancement (non-breaking change which enhances functionality)
- [x] Bug Fix (non-breaking change which fixes an issue).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist


- [x] I have read the **[CONTRIBUTING](./CONTRIBUTING.md)** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
